### PR TITLE
feature: add default/prefilled values

### DIFF
--- a/admin/src/components/SortableInput/index.tsx
+++ b/admin/src/components/SortableInput/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, forwardRef, KeyboardEvent, useMemo, useState } from 'react';
+import { ChangeEvent, forwardRef, KeyboardEvent, useEffect, useMemo, useState } from 'react';
 import { useField, type InputProps } from '@strapi/strapi/admin';
 import { Field, Flex } from '@strapi/design-system';
 import { Item } from '../Item';
@@ -23,6 +23,7 @@ type SortableInputProps = InputProps & {
   attribute: {
     options: {
       inputRegex?: string;
+      defaultValue?: string;
     };
   };
 };
@@ -43,6 +44,7 @@ const SortableInput = forwardRef<HTMLDivElement, SortableInputProps>(
     const field = useField(name);
 
     const regexPattern = attribute.options?.inputRegex;
+    const defaultValue = attribute.options?.defaultValue;
 
     const [errorString, setErrorString] = useState(field.error);
     const [inputValue, setInputValue] = useState('');
@@ -51,8 +53,25 @@ const SortableInput = forwardRef<HTMLDivElement, SortableInputProps>(
       if (Array.isArray(field.value)) {
         return field.value.map((item: string) => createItem(item));
       }
+      if (defaultValue) {
+        const defaults = defaultValue
+          .split('\n')
+          .map((s) => s.trim())
+          .filter((s) => s !== '');
+        if (defaults.length > 0) return defaults.map(createItem);
+      }
       return [];
     });
+
+    useEffect(() => {
+      if (!Array.isArray(field.value) && defaultValue) {
+        const defaults = defaultValue
+          .split('\n')
+          .map((s) => s.trim())
+          .filter((s) => s !== '');
+        if (defaults.length > 0) field.onChange(name, defaults);
+      }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
     const sensors = useSensors(
       useSensor(PointerSensor),
       useSensor(KeyboardSensor, {

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -33,6 +33,18 @@ export default {
         advanced: [
           {
             intlLabel: {
+              id: `${PLUGIN_ID}.options.advanced.defaultValue`,
+              defaultMessage: 'Default value',
+            },
+            name: 'options.defaultValue',
+            type: 'textarea',
+            description: {
+              id: `${PLUGIN_ID}.options.advanced.defaultValue.description`,
+              defaultMessage: 'One item per line. Pre-fills the list when creating a new entry.',
+            },
+          },
+          {
+            intlLabel: {
               id: `${PLUGIN_ID}.options.advanced.regex`,
               defaultMessage: 'RegExp pattern',
             },

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -1,5 +1,7 @@
 {
   "strapi-plugin-sortable-list.plugin.name": "Sortable List",
+  "strapi-plugin-sortable-list.options.advanced.defaultValue": "Default value",
+  "strapi-plugin-sortable-list.options.advanced.defaultValue.description": "One item per line. Pre-fills the list when creating a new entry.",
   "strapi-plugin-sortable-list.label": "Sortable List",
   "strapi-plugin-sortable-list.description": "Add multiple values to a sortable list",
   "strapi-plugin-sortable-list.options.advanced.regex": "RegExp pattern",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strapi-plugin-sortable-list",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "strapi-plugin-sortable-list",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.2",
+  "version": "0.4.0",
   "keywords": [
     "strapi",
     "strapi-plugin",


### PR DESCRIPTION
# Changes
Add feature: new advanced option `defaultValue`

**When a default value is defined, new content creation will come prefilled with the `defaultValue`.**

_Note: it does not act as a fallback value, in case of a empty "Sortable List Field". So the user can still leave the field empty if he whishes so_

| Admin panel -> adding the field | Content Manager panel -> creating new content with the field|
|:---------:|:------:|
| <img width="815" height="577" alt="image" src="https://github.com/user-attachments/assets/912c371c-b4ab-444c-9438-fb5a3956d199" /> | <img width="530" height="222" alt="image" src="https://github.com/user-attachments/assets/f5ed44f6-39ac-4482-98ea-fb7ee3596d14" /> |
